### PR TITLE
Include other build files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
+# build files
+build
 framework
+src
+secp256k1
+
+# vim files
+*.swp
+*.swo


### PR DESCRIPTION

#### Changes
This adds several build files to the `.gitignore` so that after executing `./shared`, `git status` is clean.
Reviewers @beyonderyue